### PR TITLE
Serve minimal static page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+simple-server

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Worldbeing Prototype
+
+This project currently serves a minimal static page with an interactive Leaflet map. The files live under the `public` directory so Vercel can deploy them with no special configuration.
+
+## Deploying to Vercel
+
+1. Install the [Vercel CLI](https://vercel.com/docs/cli) and log in.
+2. Run `vercel` the first time to set up the project.
+3. Deploy to production with:
+   ```bash
+   vercel --prod
+   ```
+4. Visit `https://<your-project>.vercel.app` (or your linked domain) to see the map.
+
+If you previously used the Haskell server in this repository, it has been removed so the deployment is purely static. You can reintroduce it later or host it separately if needed.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>World Map</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <style>
+    #map { height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script>
+    var map = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,33 @@
   <title>World Map</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <style>
+    body { margin: 0; }
     #map { height: 100vh; }
+    #title {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      font-family: Helvetica, Arial, sans-serif;
+      background: rgba(255, 255, 255, 0.8);
+      padding: 6px 10px;
+      border-radius: 4px;
+      pointer-events: none;
+    }
+    #title h1 {
+      margin: 0;
+      font-size: 20px;
+    }
+    #title p {
+      margin: 0;
+      font-size: 14px;
+    }
   </style>
 </head>
 <body>
+  <div id="title">
+    <h1>WORLDBEING</h1>
+    <p>osint ontologized</p>
+  </div>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- drop the Haskell server
- keep only the static map page under `public`
- simplify README with Vercel deployment steps

## Testing
- `curl -I https://worldbeing.vercel.app` *(fails: CONNECT tunnel failed, response 403)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68450f7296a88327beb2bb1d79195792