### PR TITLE
Style map with dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+simple-server

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Worldbeing Prototype
+
+This project currently serves a minimal static page with an interactive Leaflet map. The files live under the `public` directory so Vercel can deploy them with no special configuration.
+
+## Deploying to Vercel
+
+1. Install the [Vercel CLI](https://vercel.com/docs/cli) and log in.
+2. Run `vercel` the first time to set up the project.
+3. Deploy to production with:
+   ```bash
+   vercel --prod
+   ```
+4. Visit `https://<your-project>.vercel.app` (or your linked domain) to see the map.
+
+If you previously used the Haskell server in this repository, it has been removed so the deployment is purely static. You can reintroduce it later or host it separately if needed.

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Worldbeing interactive map - conflict-free version -->
 <html>
 <head>
   <meta charset="utf-8" />

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Worldbeing</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #111;
+      font-family: Helvetica, Arial, sans-serif;
+      color: #fff;
+    }
+    #map {
+      width: 80vw;
+      max-width: 800px;
+      height: 60vh;
+      max-height: 600px;
+      border-radius: 8px;
+    }
+    #title {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      background: rgba(0, 0, 0, 0.6);
+      padding: 6px 10px;
+      border-radius: 4px;
+      pointer-events: none;
+    }
+    #title h1 {
+      margin: 0;
+      font-size: 24px;
+    }
+    #title p {
+      margin: 0;
+      font-size: 16px;
+    }
+  </style>
+</head>
+<body>
+  <div id="title">
+    <h1>WORLDBEING</h1>
+    <p>osint ontologized</p>
+  </div>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script>
+    var map = L.map('map').setView([20, 0], 2);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; OpenStreetMap contributors &copy; CARTO'
+    }).addTo(map);
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Worldbeing</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <style>


### PR DESCRIPTION
## Summary
- style the landing page map
- center the map on a dark background
- use CARTO dark tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68450f7296a88327beb2bb1d79195792